### PR TITLE
added begin and rescue to support old and new version for File.exists…

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,9 +42,16 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        if File.exists?(config)
-          # puts "Configuration: #{config}"
-          require config
+        begin
+          if File.exists?(config)
+            # puts "Configuration: #{config}"
+            require config
+          end
+        rescue NoMethodError
+          if File.exist?(config)
+            # puts "Configuration: #{config}"
+            require config
+          end
         end
       end
     end


### PR DESCRIPTION
**File.exists?** method is depreciated to **File.exists?** in the Ruby version >=3.1.0. Added the begin and rescue to support old version < 3.1.0 and new version >=3.1.0. 