### PR TITLE
Revert "added begin and rescue to support old and new version for File.exists…"

### DIFF
--- a/lib/configatron/integrations/rails.rb
+++ b/lib/configatron/integrations/rails.rb
@@ -42,16 +42,9 @@ module Configatron::Integrations
       config_files.collect! {|config| File.expand_path(config)}.uniq!
 
       config_files.each do |config|
-        begin
-          if File.exists?(config)
-            # puts "Configuration: #{config}"
-            require config
-          end
-        rescue NoMethodError
-          if File.exist?(config)
-            # puts "Configuration: #{config}"
-            require config
-          end
+        if File.exists?(config)
+          # puts "Configuration: #{config}"
+          require config
         end
       end
     end


### PR DESCRIPTION
Reverts acl-services/configatron#2
v4.1.2 already has the fix which we want, so reverting our PR.